### PR TITLE
Fix price/date extraction on Amazon UK + add GBP currency

### DIFF
--- a/AmazonExporter.user.js
+++ b/AmazonExporter.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         Amazon Order Exporter
-// @version      0.4.2
+// @version      0.4.3
 // @description  Export Amazon order history to JSON/CSV
 // @author       IeuanK
 // @url          https://github.com/IeuanK/AmazonExporter/raw/main/AmazonExporter.user.js
@@ -253,17 +253,37 @@
                     continue;
                 }
 
-                // Extract total price (€33.98 format)
-                const priceElem = orderHeader.querySelector(".a-column.a-span2 .a-size-base, .yohtmlc-order-total .value");
+                // Locate a field by its caps label (e.g. "Total", "Order placed").
+                // Resilient to column-width changes (a-span2 vs a-span9) that Amazon
+                // ships regionally and over time.
+                const findByLabel = (labelRegex) => {
+                    const labels = orderHeader.querySelectorAll(".a-text-caps");
+                    for (const l of labels) {
+                        if (labelRegex.test(l.textContent.trim())) {
+                            const col = l.closest(".a-column") || l.parentElement?.parentElement;
+                            return col?.querySelector(".a-size-base, .value");
+                        }
+                    }
+                    return null;
+                };
+
+                // Extract total price (£8.75 / €33.98 / $12.00 format)
+                const priceElem =
+                    findByLabel(/^total$/i) ||
+                    orderHeader.querySelector(".yohtmlc-order-total .a-size-base, .yohtmlc-order-total .value, .a-column.a-span2 .a-size-base");
                 if (!priceElem) {
                     throw new Error("Could not find price element");
                 }
                 const priceText = priceElem.textContent.trim();
-                const currency = priceText.startsWith("€") ? "EUR" : "USD";
+                const currency = priceText.startsWith("€") ? "EUR"
+                               : priceText.startsWith("£") ? "GBP"
+                               : "USD";
                 const totalPrice = parseFloat(priceText.replace(/[^0-9.,]/g, "").replace(",", "."));
 
                 // Extract order date
-                const dateElem = orderHeader.querySelector(".a-column.a-span3 .a-size-base, .a-column.a-span3 .value");
+                const dateElem =
+                    findByLabel(/order placed|ordered on/i) ||
+                    orderHeader.querySelector(".a-column.a-span3 .a-size-base, .a-column.a-span3 .value");
                 if (!dateElem) {
                     throw new Error("Could not find date element");
                 }


### PR DESCRIPTION
## Issue

On `amazon.co.uk/gp/css/order-history`, capture fails for every order with:

> `[Amazon Exporter Error]: Error processing order: Error: Could not find price element`

Inspecting the current UK DOM shows Amazon has changed the order-header layout:

- The total is no longer inside `.yohtmlc-order-total` at all.
- The total's column is now `.a-column.a-span9` (not `.a-span2`), while the date has stayed in `.a-column.a-span3`. Column widths turn out to be unreliable across regions and over time — the `.com` / `.de` / `.nl` layouts still differ from each other.
- UK totals are rendered as `£8.75`, which the script didn't recognise — currency silently fell through to `"USD"`.

Sample of the current UK header markup:

```html
<div class="a-column a-span9 a-span-last">
  <li class="order-header__header-list-item" role="presentation">
    <div class="a-row a-size-mini">
      <span class="a-color-secondary a-text-caps">Total</span>
    </div>
    <div class="a-row">
      <span class="a-size-base a-color-secondary aok-break-word">£8.75</span>
    </div>
  </li>
</div>
```

## Fix

Instead of chasing Amazon's column-width churn, locate the total and order date by their caps labels (`Total`, `Order placed`) and then read the adjacent `.a-size-base` value inside the same `.a-column`. A small `findByLabel(labelRegex)` helper does the walk.

- Old selectors are retained as fallbacks after `findByLabel`, so `.com` / `.de` / `.nl` keep working if they differ.
- Currency detection now maps `£` → `GBP` alongside existing `€` → `EUR` and default `USD`.
- Bumped `@version` to `0.4.3`.

## Test plan

- [x] Verified the new selector resolves `£8.75` against the live `.co.uk` DOM
- [x] Existing `.a-column.a-span2 .a-size-base` selector retained as fallback so `.com` / `.de` / `.nl` aren't regressed
- [ ] Maintainer: smoke-test on a `.com` orders page to confirm no regression